### PR TITLE
Make output deterministic for toMap method of AuthenticationTokenHead…

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
@@ -37,7 +37,7 @@ import java.security.Signature;
 import java.security.SignatureException;
 import java.text.ParseException;
 import java.time.Instant;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -85,8 +85,13 @@ public class AuthenticationToken {
             return this.keyId;
         }
 
+        /**
+         * LinkedHashMap is purposely used to maintain deterministic output.
+         * Function is called to create the token signature and to verify it.
+         * If the order of keys returned is different for these calls, token verification fails.
+         */
         Map<String, Object> toMap() {
-            final Map<String, Object> headerMap = new HashMap<>(3, 1);
+            final Map<String, Object> headerMap = new LinkedHashMap<>(3, 1);
             headerMap.put("alg", "ES256");
             headerMap.put("typ", "JWT");
             headerMap.put("kid", this.keyId);
@@ -128,8 +133,13 @@ public class AuthenticationToken {
             return this.issuedAt;
         }
 
+        /**
+         * LinkedHashMap is purposely used to maintain deterministic output.
+         * Function is called to create the token signature and to verify it.
+         * If the order of keys returned is different for these calls, token verification fails.
+         */
         Map<String, Object> toMap() {
-            final Map<String, Object> headerMap = new HashMap<>(2, 1);
+            final Map<String, Object> headerMap = new LinkedHashMap<>(2, 1);
             headerMap.put("iss", this.issuer);
             headerMap.put("iat", this.issuedAt.getEpochSecond());
 


### PR DESCRIPTION
**Setup**:
Java version: 11.0.20
Maven version: Apache Maven 3.6.3

Was tested locally and on the given VM. Both had the same settings mentioned above and used linux OS. 

**Explanation of problem**:
The AuthenticationToken class' constructor uses `toMap()` method on `AuthenticationTokenHeader` and `AuthenticationTokenClaims` [Link](https://github.com/zzjas/pushy/blob/main/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java#L158-L159) to convert these objects into maps and finally to strings and bytes before signing them. In the same class the verifySignature method [Link](https://github.com/zzjas/pushy/blob/main/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java#L267-L305) uses `toMap()` on the header and claims objects and converts these to bytes(same as constructor), and uses it as payload to verify the signature. 

Since the key value pairs are unordered in a HashMap, the output of `toMap` is non deterministic and this leads to the signature not getting verified at times, when the results are different between the constructor and verification function.


**Fix**:
Use a LinkedHashMap instead of a HashMap in order to have an ordered set of keys. This way for a given `AuthenticationToken`, every call to the `toMap` function, will return the same order of keys for the header and claims members, and result in the same payload used to create the signature. This ensures that only the contents of the header, claims and the signing, verifying keys(public, private key) determine the signature verification process, which is what is intended. The output of `toMap` goes into a custom serializer whose output maintains the order of the map's keys: [Link](https://github.com/zzjas/pushy/blob/main/pushy/src/main/java/com/eatthepath/json/JsonSerializer.java#L136).

Linked hash map has same time complexity for all operations as a HashMap. It's internally storage occupies more space, however since the following use case/ code only hardcodes and stores 2-3 keys(in both `AuthenticationTokenHeader` and `AuthenticationTokenClaims`), with no reason/scope for drastic size increase in future, there will be no noticeable difference in performance.

The following 11 tests(/test classes as some were parameterized tests) were flaky:

- com.eatthepath.pushy.apns.ApnsClientTest#testSendNotification{boolean} 
- com.eatthepath.pushy.apns.ApnsClientTest#testSendNotificationWithPushTypeHeader{PushType}

- com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithEmptyPayload
- com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithCollapseId
- com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithExpirationDate
- com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithSpecifiedPriority
- com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithMissingPayload
- com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithOversizedPayload
- com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithWithExpiredAuthenticationToken 
- com.eatthepath.pushy.apns.auth.AuthenticationTokenTest#testVerifySignature
- com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithValidNotification


**Results**:

Steps:
1. Clone repo: `git clone https://github.com/zzjas/pushy`
2. `cd pushy`
3. Compile the module: `mvn install -pl pushy -am -DskipTests`

Non dex tool run cmd: `mvn -pl pushy edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithWithExpiredAuthenticationToken`

The following test using nondex tool shows how the map order has changed and results in an invalid token:

![dex_mode_fail](https://github.com/zzjas/pushy/assets/22187598/6890357f-7acb-4eaa-82d8-61838b861025)

When the random seed does not shuffle the map it works fine:

![dex_mode_pass](https://github.com/zzjas/pushy/assets/22187598/8c5666a9-6243-4725-b5b2-9c14f2193aaf)

The test passed when ran without dex tool using the command:
`mvn -pl pushy test -Dtest=com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithWithExpiredAuthenticationToken`

![passes_in_normal_mode](https://github.com/zzjas/pushy/assets/22187598/dd826942-9e7d-4385-961d-c1409dfdc306)



This flaky test was fixed with the change and ran successfully for all variants in the non-dex mode:

![dex_pass_post_fix](https://github.com/zzjas/pushy/assets/22187598/4e7322fa-c33f-4da9-8de9-28cdda9dd4b8)

This change additionally fixed 10 tests, as the expected error was due to some other check which happened after verifysignature method, which was failing. 

non dex report before fix(for all tests in module):
cmd: `mvn -pl pushy edu.illinois:nondex-maven-plugin:2.1.1:nondex |& tee mp1_non_dex_log_prefix.txt`

![test_failures_before_fix](https://github.com/zzjas/pushy/assets/22187598/254d6966-c09d-4534-b94b-463e03a66e1b)


non dex report post fix(for all tests in module):
cmd: `mvn -pl pushy edu.illinois:nondex-maven-plugin:2.1.1:nondex |& tee mp1_non_dex_log_postfix.txt`
![no_failures_after_fix](https://github.com/zzjas/pushy/assets/22187598/994b952a-1a2e-4872-b502-b625218bca30)
